### PR TITLE
Add volume mapping for PostgreSQL service in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           POSTGRES_DB: todos_db
         ports:
           - 54322:5432
+        volumes:
+          - ${{ github.workspace }}/postgres/init:/docker-entrypoint-initdb.d
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
           POSTGRES_DB: todos_db
         ports:
           - 54322:5432
-        volumes:
-          - ${{ github.workspace }}/postgres/init:/docker-entrypoint-initdb.d
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -33,6 +31,10 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Database
+        run: |
+          PGPASSWORD=__ENTER_POSTGRES_PASSWORD_HERE__ psql -h localhost -p 54322 -U postgres -d todos_db -f ../../postgres/init/01_create_todos.sql
+          PGPASSWORD=__ENTER_POSTGRES_PASSWORD_HERE__ psql -h localhost -p 54322 -U postgres -d todos_db -f ../../postgres/init/99_create_examples.sql
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Database
         run: |
+          # HACK: docker-entrypoint-initdb.d 用の SQL ファイルを直接実行する
+          # テスト実行用のテーブルを作成するため。もっといい方法あるはず
           PGPASSWORD=__ENTER_POSTGRES_PASSWORD_HERE__ psql -h localhost -p 54322 -U postgres -d todos_db -f ../../postgres/init/01_create_todos.sql
           PGPASSWORD=__ENTER_POSTGRES_PASSWORD_HERE__ psql -h localhost -p 54322 -U postgres -d todos_db -f ../../postgres/init/99_create_examples.sql
       - name: Setup Java


### PR DESCRIPTION
This pull request updates the `ci.yml` workflow configuration to enhance the initialization process for the PostgreSQL service.

Workflow configuration update:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR27-R28): Added a `volumes` directive to mount the `postgres/init` directory from the GitHub workspace to the container's `docker-entrypoint-initdb.d`. This allows custom initialization scripts to be executed when the PostgreSQL container starts.<!-- I want to review in Japanese and English. -->

<!--
Example:
----------------------------
[must] The condition for FizzBuzz is unreachable because the checks for Fizz and Buzz occur first. Place the FizzBuzz check before these individual conditions to ensure correct behavior.
[must] FizzBuzz の条件には到達できないだなも。なぜなら、先に Fizz と Buzz のチェックが行われているためだなも。正しい動作を保証するために、FizzBuzz のチェックをこれら個別の条件より前に配置してほしいだなも。
----------------------------
-->

<!-- For Japanese translations, please use the Animal Crossing character Tanukichi's speaking style ("だなも") at the end of each sentence. -->

<!-- I want to review in Japanese and English. -->
