### PR TITLE
Enhance TodoRestControllerTests with additional assertions for respon…

### DIFF
--- a/src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.java
+++ b/src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.java
@@ -40,7 +40,6 @@ public class TodoRestControllerTests {
     @BeforeEach
     void setUp() {
         objectMapper = new ObjectMapper();
-        // テストデータをクリア
         todoRepository.findAll().forEach(todo -> todoRepository.delete(todo));
     }
 
@@ -203,7 +202,7 @@ public class TodoRestControllerTests {
 
             // Assert
             var allTodos = todoRepository.findAll();
-            assertEquals(5, allTodos.size()); // 上限の5個のままで増えていない
+            assertEquals(5, allTodos.size()); // 上限の 5 個のままで増えていない
             assertTrue(allTodos.stream().noneMatch(todo -> "Overflow Todo".equals(todo.getTodoTitle())));
         }
 

--- a/src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.java
+++ b/src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collection;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -115,7 +117,7 @@ public class TodoRestControllerTests {
             // Assert
             JsonNode responseBody = objectMapper.readTree(response.getBody());
             String createdTodoId = responseBody.get("todoId").asText();
-            var savedTodo = todoRepository.findById(createdTodoId);
+            Todo savedTodo = todoRepository.findById(createdTodoId);
             assertNotNull(savedTodo);
             assertEquals(createdTodoId, savedTodo.getTodoId());
             assertEquals("Hello World!", savedTodo.getTodoTitle());
@@ -201,7 +203,7 @@ public class TodoRestControllerTests {
             restTemplate.postForEntity("/v1/todos", requestEntity, String.class);
 
             // Assert
-            var allTodos = todoRepository.findAll();
+            Collection<Todo> allTodos = todoRepository.findAll();
             assertEquals(5, allTodos.size()); // 上限の 5 個のままで増えていない
             assertTrue(allTodos.stream().noneMatch(todo -> "Overflow Todo".equals(todo.getTodoTitle())));
         }
@@ -246,7 +248,7 @@ public class TodoRestControllerTests {
             restTemplate.postForEntity("/v1/todos", requestEntity, String.class);
 
             // Assert
-            var todosAfter = todoRepository.findAll();
+            Collection<Todo> todosAfter = todoRepository.findAll();
             assertEquals(initialCount, todosAfter.size());
         }
     }
@@ -267,7 +269,7 @@ public class TodoRestControllerTests {
                     String.class);
 
             // Assert
-            var updatedTodo = todoRepository.findById(todoId);
+            Todo updatedTodo = todoRepository.findById(todoId);
             assertNotNull(updatedTodo);
             assertEquals(todoId, updatedTodo.getTodoId());
             assertEquals("Test Todo", updatedTodo.getTodoTitle());
@@ -354,7 +356,7 @@ public class TodoRestControllerTests {
                     String.class);
 
             // Assert
-            var deletedTodo = todoRepository.findById(todoId);
+            Todo deletedTodo = todoRepository.findById(todoId);
             assertNull(deletedTodo);
         }
 

--- a/src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.java
+++ b/src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.java
@@ -78,8 +78,11 @@ public class TodoRestControllerTests {
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());
             JsonNode responseBody = objectMapper.readTree(response.getBody());
+            assertEquals(todoId, responseBody.get("todoId").asText());
             assertEquals("Test Todo", responseBody.get("todoTitle").asText());
             assertEquals("Test Description", responseBody.get("todoDescription").asText());
+            assertFalse(responseBody.get("finished").asBoolean());
+            assertNotNull(responseBody.get("createdAt").asText());
         }
 
         @Test
@@ -115,6 +118,7 @@ public class TodoRestControllerTests {
             String createdTodoId = responseBody.get("todoId").asText();
             var savedTodo = todoRepository.findById(createdTodoId);
             assertNotNull(savedTodo);
+            assertEquals(createdTodoId, savedTodo.getTodoId());
             assertEquals("Hello World!", savedTodo.getTodoTitle());
             assertEquals("Hello Todo Description!", savedTodo.getTodoDescription());
             assertFalse(savedTodo.isFinished());
@@ -140,10 +144,10 @@ public class TodoRestControllerTests {
             // Assert
             assertEquals(HttpStatus.CREATED, response.getStatusCode());
             JsonNode responseBody = objectMapper.readTree(response.getBody());
+            assertNotNull(responseBody.get("todoId").asText());
             assertEquals("Hello World!", responseBody.get("todoTitle").asText());
             assertEquals("Hello Todo Description!", responseBody.get("todoDescription").asText());
             assertFalse(responseBody.get("finished").asBoolean());
-            assertNotNull(responseBody.get("todoId").asText());
             assertNotNull(responseBody.get("createdAt").asText());
         }
 
@@ -266,9 +270,11 @@ public class TodoRestControllerTests {
             // Assert
             var updatedTodo = todoRepository.findById(todoId);
             assertNotNull(updatedTodo);
-            assertTrue(updatedTodo.isFinished());
+            assertEquals(todoId, updatedTodo.getTodoId());
             assertEquals("Test Todo", updatedTodo.getTodoTitle());
             assertEquals("Test Description", updatedTodo.getTodoDescription());
+            assertTrue(updatedTodo.isFinished());
+            assertNotNull(updatedTodo.getCreatedAt());
         }
 
         @Test
@@ -287,7 +293,11 @@ public class TodoRestControllerTests {
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());
             JsonNode responseBody = objectMapper.readTree(response.getBody());
+            assertEquals(todoId, responseBody.get("todoId").asText());
+            assertEquals("Test Todo", responseBody.get("todoTitle").asText());
+            assertEquals("Test Description", responseBody.get("todoDescription").asText());
             assertTrue(responseBody.get("finished").asBoolean());
+            assertNotNull(responseBody.get("createdAt").asText());
         }
 
         @Test


### PR DESCRIPTION
This pull request enhances the test coverage for the `TodoRestController` in the `todos-api` project. The changes ensure more robust assertions in test methods, validating additional fields and improving consistency across tests.

### Enhancements to test assertions:

* `void returnsTodoByIdWith200()`:
  Added assertions to verify `todoId`, `finished` status, and `createdAt` fields in the response body.

* `void savesTodoToDatabase()`:
  Included an assertion to confirm that the `todoId` in the response matches the `todoId` of the saved entity in the database.

* `void returnsCreatedTodoWith201()`:
  Improved assertion consistency by ensuring `todoId` and `createdAt` fields are validated in the response body. Removed duplicate assertion for `todoId`.

* `void updatesTodoToFinishedInDatabase()`:
  Added assertions to verify `todoId`, `finished` status, and `createdAt` fields of the updated entity in the database.

* `void returnsFinishedTodoWith200()`:
  Enhanced response validation by adding checks for `todoId`, `todoTitle`, `todoDescription`, and `createdAt` fields.