### PR TITLE
refactor: update test display names for clarity and consistency

### DIFF
--- a/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/common/error/RestGlobalExceptionHandlerTests.java
+++ b/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/common/error/RestGlobalExceptionHandlerTests.java
@@ -40,8 +40,8 @@ public class RestGlobalExceptionHandlerTests {
     @Nested
     class HandleSystemErrorTests {
         @Test
-        @DisplayName("システムエラーは \"500 Internal Server Error\" で返す")
-        void returns500InternalServerErrorWhenSystemError() throws JsonMappingException, JsonProcessingException {
+        @DisplayName("システムエラーは \"500 Internal Server Error\" で返すこと")
+        void shouldReturn500InternalServerErrorWhenSystemError() throws JsonMappingException, JsonProcessingException {
             // Act
             ResponseEntity<String> response = restTemplate.getForEntity(
                     "/v1/error/throw-system-error",
@@ -55,8 +55,8 @@ public class RestGlobalExceptionHandlerTests {
         }
 
         @Test
-        @DisplayName("システムエラーが発生したときはスタックトレースを返さない")
-        void notReturnsStackTraceWhenSystemError() throws JsonMappingException, JsonProcessingException {
+        @DisplayName("システムエラーが発生したときはスタックトレースを返さないこと")
+        void shouldNotReturnStackTraceWhenSystemError() throws JsonMappingException, JsonProcessingException {
             // Act
             ResponseEntity<String> response = restTemplate.getForEntity(
                     "/v1/error/throw-system-error",
@@ -71,8 +71,8 @@ public class RestGlobalExceptionHandlerTests {
     @Nested
     class HandleMethodArgumentNotValidTests {
         @Test
-        @DisplayName("引数のバリデーションエラーは \"400 Bad Request\" で返す")
-        void returns400BadRequestWhenMethodArgumentNotValidException()
+        @DisplayName("引数のバリデーションエラーは \"400 Bad Request\" で返すこと")
+        void shouldReturn400BadRequestWhenMethodArgumentNotValidException()
                 throws JsonMappingException, JsonProcessingException {
             // Arrange
             String requestBody = """
@@ -96,8 +96,8 @@ public class RestGlobalExceptionHandlerTests {
         }
 
         @Test
-        @DisplayName("引数のバリデーションエラーの数だけ errors の配列を返す")
-        void returnsErrorsForArgumentErrorTimes()
+        @DisplayName("引数のバリデーションエラーの数だけ errors の配列を返すこと")
+        void shouldReturnErrorsForArgumentErrorTimes()
                 throws JsonMappingException, JsonProcessingException {
             // Arrange
             String requestBody = """
@@ -120,8 +120,8 @@ public class RestGlobalExceptionHandlerTests {
         }
 
         @Test
-        @DisplayName("引数のバリデーションエラー要素に所定のエラー詳細内容を含む")
-        void returnsErrorsWithContainedErrorDetails()
+        @DisplayName("引数のバリデーションエラー要素に所定のエラー詳細内容を含むこと")
+        void shouldReturnErrorsWithContainedErrorDetails()
                 throws JsonMappingException, JsonProcessingException {
             // Arrange
             String requestBody = """

--- a/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/fizzbuzz/FizzBuzzRestControllerTests.java
+++ b/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/fizzbuzz/FizzBuzzRestControllerTests.java
@@ -31,11 +31,11 @@ public class FizzBuzzRestControllerTests {
     @Nested
     class GetRequestTests {
         @Nested
-        @DisplayName("正常なリクエストでは FizzBuzz 結果のレスポンスを返す")
+        @DisplayName("正常なリクエストでは FizzBuzz 結果のレスポンスを返すこと")
         class ValidRequestTests {
             @Test
-            @DisplayName("\"?num=3\" でリクエストされた場合は {\"result\": \"Fizz\"} を返す")
-            void returnsFizzFor3() throws Exception {
+            @DisplayName("\"?num=3\" でリクエストされた場合は {\"result\": \"Fizz\"} を返すこと")
+            void shouldReturnFizzFor3() throws Exception {
                 // Act
                 ResponseEntity<String> response = restTemplate.getForEntity("/v1/fizzbuzz/convert?num=3",
                         String.class);
@@ -48,11 +48,11 @@ public class FizzBuzzRestControllerTests {
         }
 
         @Nested
-        @DisplayName("不正なリクエストではエラーレスポンスを返す")
+        @DisplayName("不正なリクエストではエラーレスポンスを返すこと")
         class InvalidRequestTests {
             @Test
-            @DisplayName("パラメータ無しでリクエストされた場合はエラーレスポンスを返す")
-            void returnsErrorResponseForMissingParameter() throws Exception {
+            @DisplayName("パラメータ無しでリクエストされた場合はエラーレスポンスを返すこと")
+            void shouldReturnErrorResponseForMissingParameter() throws Exception {
                 // Act
                 ResponseEntity<String> response = restTemplate.getForEntity("/v1/fizzbuzz/convert", String.class);
 
@@ -64,8 +64,8 @@ public class FizzBuzzRestControllerTests {
             }
 
             @Test
-            @DisplayName("数値として扱えない値でリクエストされた場合はエラーレスポンスを返す")
-            void returnsErrorResponseForInvalidNumber() throws Exception {
+            @DisplayName("数値として扱えない値でリクエストされた場合はエラーレスポンスを返すこと")
+            void shouldReturnErrorResponseForInvalidNumber() throws Exception {
                 // Act
                 ResponseEntity<String> response = restTemplate.getForEntity("/v1/fizzbuzz/convert?num=abc",
                         String.class);

--- a/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/greeting/GreetingRestControllerTests.java
+++ b/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/greeting/GreetingRestControllerTests.java
@@ -20,8 +20,8 @@ public class GreetingRestControllerTests {
     @Nested
     class GetRequestTests {
         @Test
-        @DisplayName("デフォルトの名前で挨拶を返す")
-        void returnsGreetingWithDefaultName() {
+        @DisplayName("デフォルトの名前で挨拶を返すこと")
+        void shouldReturnGreetingWithDefaultName() {
             // Act
             ResponseEntity<String> response = restTemplate.getForEntity("/v1/greeting/hello",
                     String.class);
@@ -32,8 +32,8 @@ public class GreetingRestControllerTests {
         }
 
         @Test
-        @DisplayName("指定された名前で挨拶を返す")
-        void returnsGreetingWithSpecifiedName() {
+        @DisplayName("指定された名前で挨拶を返すこと")
+        void shouldReturnGreetingWithSpecifiedName() {
             // Act
             ResponseEntity<String> response = restTemplate.getForEntity("/v1/greeting/hello?name=KeM198",
                     String.class);

--- a/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/todo/TodoRestControllerTests.java
+++ b/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/todo/TodoRestControllerTests.java
@@ -49,7 +49,7 @@ public class TodoRestControllerTests {
     class GetTodosTests {
         @Test
         @DisplayName("Todo 一覧と 200 を返すこと")
-        void returnsTodoListWith200() throws Exception {
+        void shouldReturnTodoListWith200() throws Exception {
             // Arrange
             Todo todo1 = makeTestTodo("Test Todo 1", "Description 1");
             Todo todo2 = makeTestTodo("Test Todo 2", "Description 2");
@@ -71,7 +71,7 @@ public class TodoRestControllerTests {
     class GetTodoTests {
         @Test
         @DisplayName("指定された ID の Todo と 200 を返すこと")
-        void returnsTodoByIdWith200() throws Exception {
+        void shouldReturnTodoByIdWith200() throws Exception {
             // Arrange
             Todo todo = makeTestTodo("Test Todo", "Test Description");
             todoRepository.create(todo);
@@ -92,7 +92,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("存在しない ID の場合は 404 を返すこと")
-        void returnsNotFoundWith404ForNonExistentId() throws Exception {
+        void shouldReturnNotFoundWith404ForNonExistentId() throws Exception {
             // Act
             ResponseEntity<String> response = restTemplate.getForEntity("/v1/todos/nonexistent", String.class);
 
@@ -105,7 +105,7 @@ public class TodoRestControllerTests {
     class PostTodoTests {
         @Test
         @DisplayName("Todo がデータベースに保存されること")
-        void savesTodoToDatabase() throws Exception {
+        void shouldSaveTodoToDatabase() throws Exception {
             // Act
             String requestBody = """
                         {
@@ -132,7 +132,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("作成された Todo と 201 を返すこと")
-        void returnsCreatedTodoWith201() throws Exception {
+        void shouldReturnCreatedTodoWith201() throws Exception {
             // Act
             String requestBody = """
                         {
@@ -158,7 +158,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("未完了 Todo が上限に達している場合は 400 を返すこと")
-        void returnsBadRequestWith400WhenUnfinishedTodoLimitReached() throws Exception {
+        void shouldReturnBadRequestWith400WhenUnfinishedTodoLimitReached() throws Exception {
             // Arrange
             // 未完了 Todo を上限まで作成する
             for (int i = 0; i < 5; i++) {
@@ -187,7 +187,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("未完了 Todo が上限に達している場合は新しい Todo が作成されないこと")
-        void doesNotCreateTodoWhenUnfinishedTodoLimitReached() throws Exception {
+        void shouldNotCreateTodoWhenUnfinishedTodoLimitReached() throws Exception {
             // Arrange
             // 未完了 Todo を上限まで作成する
             for (int i = 0; i < 5; i++) {
@@ -216,7 +216,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("バリデーションエラーの場合は 400 を返すこと")
-        void returnsBadRequestWith400ForValidationError() throws Exception {
+        void shouldReturnBadRequestWith400ForValidationError() throws Exception {
             // Act
             String requestBody = """
                         {
@@ -236,7 +236,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("バリデーションエラーの場合は新しい Todo が作成されないこと")
-        void doesNotCreateTodoForValidationError() throws Exception {
+        void shouldNotCreateTodoForValidationError() throws Exception {
             // Arrange
             // 事前の Todo 数を確認
             int initialCount = todoRepository.findAll().size();
@@ -263,7 +263,7 @@ public class TodoRestControllerTests {
     class PutTodoTests {
         @Test
         @DisplayName("Todo がデータベースで完了状態に更新されること")
-        void updatesTodoToFinishedInDatabase() throws Exception {
+        void shouldUpdateTodoToFinishedInDatabase() throws Exception {
             // Arrange
             Todo todo = makeTestTodo("Test Todo", "Test Description");
             todoRepository.create(todo);
@@ -288,7 +288,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("完了状態の Todo と 200 を返すこと")
-        void returnsFinishedTodoWith200() throws Exception {
+        void shouldReturnFinishedTodoWith200() throws Exception {
             // Arrange
             Todo todo = makeTestTodo("Test Todo", "Test Description");
             todoRepository.create(todo);
@@ -313,7 +313,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("既に完了済みの Todo の場合は 400 を返すこと")
-        void returnsBadRequestWith400ForAlreadyFinishedTodo() throws Exception {
+        void shouldReturnBadRequestWith400ForAlreadyFinishedTodo() throws Exception {
             // Arrange
             Todo todo = makeTestTodo("Test Todo", "Test Description");
             todoRepository.create(todo);
@@ -337,7 +337,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("存在しない Todo の場合は 404 を返すこと")
-        void returnsNotFoundWith404ForNonExistentTodo() throws Exception {
+        void shouldReturnNotFoundWith404ForNonExistentTodo() throws Exception {
             // Act
             ResponseEntity<String> response = restTemplate.exchange(
                     "/v1/todos/nonexistent",
@@ -356,7 +356,7 @@ public class TodoRestControllerTests {
     class DeleteTodoTests {
         @Test
         @DisplayName("Todo がデータベースから削除されること")
-        void deletesTodoFromDatabase() throws Exception {
+        void shouldDeleteTodoFromDatabase() throws Exception {
             // Arrange
             Todo todo = makeTestTodo("Test Todo", "Test Description");
             todoRepository.create(todo);
@@ -376,7 +376,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("Todo が削除された際に 204 を返すこと")
-        void deletesTodoAndReturns204() throws Exception {
+        void shouldDeleteTodoAndReturn204() throws Exception {
             // Arrange
             Todo todo = makeTestTodo("Test Todo", "Test Description");
             todoRepository.create(todo);
@@ -395,7 +395,7 @@ public class TodoRestControllerTests {
 
         @Test
         @DisplayName("存在しない Todo の場合は 404 を返すこと")
-        void returnsNotFoundWith404ForNonExistentTodo() throws Exception {
+        void shouldReturnNotFoundWith404ForNonExistentTodoOnDelete() throws Exception {
             // Act
             ResponseEntity<String> response = restTemplate.exchange(
                     "/v1/todos/nonexistent",

--- a/src/backend/modules/todos-core/src/test/java/net/kem198/todos/core/util/FizzBuzzUtilsTests.java
+++ b/src/backend/modules/todos-core/src/test/java/net/kem198/todos/core/util/FizzBuzzUtilsTests.java
@@ -10,11 +10,11 @@ public class FizzBuzzUtilsTests {
     @Nested
     class ConvertMethodTests {
         @Nested
-        @DisplayName("3 の倍数の場合は「Fizz」に変換する")
+        @DisplayName("3 の倍数の場合は「Fizz」に変換すること")
         class ConvertsMultiplesOf3ToFizz {
             @Test
-            @DisplayName("3 を渡すと文字列 Fizz を返す")
-            void returnsFizzFor3() {
+            @DisplayName("3 を渡すと文字列 Fizz を返すこと")
+            void shouldReturnFizzFor3() {
                 // Act
                 String actual = FizzBuzzUtils.convert(3);
 
@@ -24,11 +24,11 @@ public class FizzBuzzUtilsTests {
         }
 
         @Nested
-        @DisplayName("5 の倍数の場合は「Buzz」に変換する")
+        @DisplayName("5 の倍数の場合は「Buzz」に変換すること")
         class ConvertsMultiplesOf5ToBuzz {
             @Test
-            @DisplayName("5 を渡すと文字列 Buzz を返す")
-            void returnsBuzzFor5() {
+            @DisplayName("5 を渡すと文字列 Buzz を返すこと")
+            void shouldReturnBuzzFor5() {
                 // Act
                 String actual = FizzBuzzUtils.convert(5);
 
@@ -38,11 +38,11 @@ public class FizzBuzzUtilsTests {
         }
 
         @Nested
-        @DisplayName("3 と 5 両方の倍数の場合は「FizzBuzz」に変換する")
+        @DisplayName("3 と 5 両方の倍数の場合は「FizzBuzz」に変換すること")
         class ConvertsMultiplesOf3And5ToFizzBuzz {
             @Test
-            @DisplayName("15 を渡すと文字列 FizzBuzz を返す")
-            void returnsFizzBuzzFor15() {
+            @DisplayName("15 を渡すと文字列 FizzBuzz を返すこと")
+            void shouldReturnFizzBuzzFor15() {
                 // Act
                 String actual = FizzBuzzUtils.convert(15);
 
@@ -52,11 +52,11 @@ public class FizzBuzzUtilsTests {
         }
 
         @Nested
-        @DisplayName("その他の数の場合はそのまま文字列に変換する")
+        @DisplayName("その他の数の場合はそのまま文字列に変換すること")
         class ConvertsOtherNumbersToString {
             @Test
-            @DisplayName("1 を渡すと文字列 1 を返す")
-            void returns1For1() {
+            @DisplayName("1 を渡すと文字列 1 を返すこと")
+            void shouldReturn1For1() {
                 // Act
                 String actual = FizzBuzzUtils.convert(1);
 

--- a/src/backend/modules/todos-infrastructure/src/test/java/net/kem198/todos/infrastructure/repository/todo/TodoRepositoryImplTests.java
+++ b/src/backend/modules/todos-infrastructure/src/test/java/net/kem198/todos/infrastructure/repository/todo/TodoRepositoryImplTests.java
@@ -33,8 +33,8 @@ public class TodoRepositoryImplTests {
     @Nested
     class FindByIdTests {
         @Test
-        @DisplayName("引数の todoId と一致する Todo を返す")
-        public void returnsTodoForMatchingTodoId() {
+        @DisplayName("引数の todoId と一致する Todo を返すこと")
+        public void shouldReturnTodoForMatchingTodoId() {
             // Arrange
             Todo expectedTodo = makeTestTodo("Test Todo", false);
             todoRepository.create(expectedTodo);
@@ -51,8 +51,8 @@ public class TodoRepositoryImplTests {
         }
 
         @Test
-        @DisplayName("引数の todoId と一致する Todo が存在しない場合は null を返す")
-        public void returnsNullForNonExistentTodoId() {
+        @DisplayName("引数の todoId と一致する Todo が存在しない場合は null を返すこと")
+        public void shouldReturnNullForNonExistentTodoId() {
             // Arrange
             String nonExistentId = UUID.randomUUID().toString();
 
@@ -67,8 +67,8 @@ public class TodoRepositoryImplTests {
     @Nested
     class FindAllTests {
         @Test
-        @DisplayName("全ての Todo を Collection 形式で返す")
-        public void returnsAllTodosAsCollection() {
+        @DisplayName("全ての Todo を Collection 形式で返すこと")
+        public void shouldReturnAllTodosAsCollection() {
             // Arrange
             Todo todo1 = makeTestTodo("Test Todo 1", false);
             Todo todo2 = makeTestTodo("Test Todo 2", true);
@@ -85,8 +85,8 @@ public class TodoRepositoryImplTests {
         }
 
         @Test
-        @DisplayName("Todo が存在しない場合は空の Collection を返す")
-        public void returnsEmptyCollectionWhenNoTodosExist() {
+        @DisplayName("Todo が存在しない場合は空の Collection を返すこと")
+        public void shouldReturnEmptyCollectionWhenNoTodosExist() {
             // Act
             Collection<Todo> todos = todoRepository.findAll();
 
@@ -99,8 +99,8 @@ public class TodoRepositoryImplTests {
     @Nested
     class CreateTests {
         @Test
-        @DisplayName("Todo を作成する")
-        public void createsTodoSuccessfully() {
+        @DisplayName("Todo を作成すること")
+        public void shouldCreateTodoSuccessfully() {
             // Arrange
             Todo newTodo = makeTestTodo("New Todo", false);
 
@@ -120,8 +120,8 @@ public class TodoRepositoryImplTests {
     @Nested
     class UpdateTests {
         @Test
-        @DisplayName("存在する Todo を更新する")
-        public void updatesTodoSuccessfully() {
+        @DisplayName("存在する Todo を更新すること")
+        public void shouldUpdateTodoSuccessfully() {
             // Arrange
             Todo originalTodo = makeTestTodo("Original Todo", false);
             todoRepository.create(originalTodo);
@@ -142,8 +142,8 @@ public class TodoRepositoryImplTests {
         }
 
         @Test
-        @DisplayName("存在しない Todo の更新は false を返す")
-        public void returnsFalseForNonExistentTodo() {
+        @DisplayName("存在しない Todo の更新は false を返すこと")
+        public void shouldReturnFalseForNonExistentTodo() {
             // Arrange
             Todo nonExistentTodo = makeTestTodo("Non-existent Todo", false);
 
@@ -158,8 +158,8 @@ public class TodoRepositoryImplTests {
     @Nested
     class DeleteTests {
         @Test
-        @DisplayName("存在する Todo を削除する")
-        public void deletesTodoSuccessfully() {
+        @DisplayName("存在する Todo を削除すること")
+        public void shouldDeleteTodoSuccessfully() {
             // Arrange
             Todo todoToDelete = makeTestTodo("Todo to Delete", false);
             todoRepository.create(todoToDelete);
@@ -173,8 +173,8 @@ public class TodoRepositoryImplTests {
         }
 
         @Test
-        @DisplayName("存在しない Todo の削除でもエラーが発生しない")
-        public void doesNotThrowErrorForNonExistentTodo() {
+        @DisplayName("存在しない Todo の削除でもエラーが発生しないこと")
+        public void shouldNotThrowErrorForNonExistentTodo() {
             // Arrange
             Todo nonExistentTodo = makeTestTodo("Non-existent Todo", false);
 
@@ -186,8 +186,8 @@ public class TodoRepositoryImplTests {
     @Nested
     class CountByFinishedTests {
         @Test
-        @DisplayName("未完了の Todo の数を返す")
-        public void returnsCorrectCountForUnfinishedTodos() {
+        @DisplayName("未完了の Todo の数を返すこと")
+        public void shouldReturnCorrectCountForUnfinishedTodos() {
             // Arrange
             Todo unfinishedTodo1 = makeTestTodo("Unfinished Todo 1", false);
             Todo unfinishedTodo2 = makeTestTodo("Unfinished Todo 2", false);
@@ -205,8 +205,8 @@ public class TodoRepositoryImplTests {
         }
 
         @Test
-        @DisplayName("完了済みの Todo の数を返す")
-        public void returnsCorrectCountForFinishedTodos() {
+        @DisplayName("完了済みの Todo の数を返すこと")
+        public void shouldReturnCorrectCountForFinishedTodos() {
             // Arrange
             Todo unfinishedTodo = makeTestTodo("Unfinished Todo", false);
             Todo finishedTodo1 = makeTestTodo("Finished Todo 1", true);
@@ -224,8 +224,8 @@ public class TodoRepositoryImplTests {
         }
 
         @Test
-        @DisplayName("該当する Todo が存在しない場合は 0 を返す")
-        public void returnsZeroWhenNoMatchingTodosExist() {
+        @DisplayName("該当する Todo が存在しない場合は 0 を返すこと")
+        public void shouldReturnZeroWhenNoMatchingTodosExist() {
             // Arrange
             Todo finishedTodo = makeTestTodo("Finished Todo", true);
             todoRepository.create(finishedTodo);


### PR DESCRIPTION
This pull request updates test method names and their `@DisplayName` annotations across several test classes to improve readability and consistency. The changes ensure that method names and display names follow a more descriptive and standardized format, making the tests easier to understand.

### Updates to test method names and `@DisplayName` annotations:

#### Error handling tests (`RestGlobalExceptionHandlerTests`):
* Renamed methods to use "should" in their names for clarity, e.g., `returns500InternalServerErrorWhenSystemError` → `shouldReturn500InternalServerErrorWhenSystemError`. Updated `@DisplayName` annotations to end with "こと" for consistency. [[1]](diffhunk://#diff-65c50e0e57b42b54bfc73902bdbc997386bdb5631efb175b306447dab4f60d46L43-R44) [[2]](diffhunk://#diff-65c50e0e57b42b54bfc73902bdbc997386bdb5631efb175b306447dab4f60d46L58-R59) [[3]](diffhunk://#diff-65c50e0e57b42b54bfc73902bdbc997386bdb5631efb175b306447dab4f60d46L74-R75) [[4]](diffhunk://#diff-65c50e0e57b42b54bfc73902bdbc997386bdb5631efb175b306447dab4f60d46L99-R100) [[5]](diffhunk://#diff-65c50e0e57b42b54bfc73902bdbc997386bdb5631efb175b306447dab4f60d46L123-R124)

#### FizzBuzz API tests (`FizzBuzzRestControllerTests`):
* Renamed methods and updated `@DisplayName` annotations for both valid and invalid request tests, e.g., `returnsFizzFor3` → `shouldReturnFizzFor3`. [[1]](diffhunk://#diff-9f8720235126d6ec433304b2ba1a2257737bf835078608c6a1066e478583c878L34-R38) [[2]](diffhunk://#diff-9f8720235126d6ec433304b2ba1a2257737bf835078608c6a1066e478583c878L51-R55) [[3]](diffhunk://#diff-9f8720235126d6ec433304b2ba1a2257737bf835078608c6a1066e478583c878L67-R68)

#### Greeting API tests (`GreetingRestControllerTests`):
* Updated method names and `@DisplayName` annotations for greeting tests, e.g., `returnsGreetingWithDefaultName` → `shouldReturnGreetingWithDefaultName`. [[1]](diffhunk://#diff-d505074d44963317ecb87874501db0f6f38eb3fd0015fc2f9380db77ecd05f2eL23-R24) [[2]](diffhunk://#diff-d505074d44963317ecb87874501db0f6f38eb3fd0015fc2f9380db77ecd05f2eL35-R36)

#### Todo API tests (`TodoRestControllerTests`):
* Applied naming updates across multiple test scenarios, including retrieval, creation, update, and deletion of Todos, e.g., `returnsTodoListWith200` → `shouldReturnTodoListWith200`. [[1]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L52-R52) [[2]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L74-R74) [[3]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L95-R95) [[4]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L108-R108) [[5]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L135-R135) [[6]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L161-R161) [[7]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L190-R190) [[8]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L219-R219) [[9]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L239-R239) [[10]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L266-R266) [[11]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L291-R291) [[12]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L316-R316) [[13]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L340-R340) [[14]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L359-R359) [[15]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L379-R379) [[16]](diffhunk://#diff-40ca151b65dacd2636e8010a447285db6ff177290c257e13fece86b06ca23125L398-R398)

#### FizzBuzz utility tests (`FizzBuzzUtilsTests`):
* Updated method names and `@DisplayName` annotations for FizzBuzz conversion tests, e.g., `returnsFizzFor3` → `shouldReturnFizzFor3`. [[1]](diffhunk://#diff-3b2cbd6783295657ae0ab38c3cc97a69b891a54c3fb8789c737521cc6a186248L13-R17) [[2]](diffhunk://#diff-3b2cbd6783295657ae0ab38c3cc97a69b891a54c3fb8789c737521cc6a186248L27-R31)